### PR TITLE
Warn on non-escaped path arguments

### DIFF
--- a/src/gourd_lib/config/maps.rs
+++ b/src/gourd_lib/config/maps.rs
@@ -18,6 +18,7 @@ use crate::constants::GLOB_ESCAPE;
 use crate::constants::HELP_STYLE;
 use crate::constants::INTERNAL_GLOB;
 use crate::constants::INTERNAL_PREFIX;
+use crate::constants::PRIMARY_STYLE;
 use crate::constants::WARNING_STYLE;
 use crate::ctx;
 use crate::file_system::FileOperations;
@@ -71,7 +72,8 @@ pub fn expand_argument_globs(
             let mut next_globset = HashSet::new();
 
             for input_instance in &globset {
-                is_glob |= explode_glob_set(input_instance, arg_index, &mut next_globset, fs)?;
+                is_glob |=
+                    explode_glob_set(input_instance, original, arg_index, &mut next_globset, fs)?;
             }
 
             swap(&mut globset, &mut next_globset);
@@ -96,6 +98,7 @@ pub fn expand_argument_globs(
 /// argument and put the results in `fill`.
 fn explode_glob_set(
     input: &UserInput,
+    input_name: &str, // only used for warnings.
     arg_index: usize,
     fill: &mut HashSet<UserInput>,
     fs: &impl FileOperations,
@@ -131,6 +134,7 @@ fn explode_glob_set(
                 " \n\
                 It looks like you specified a path argument: \
                 {WARNING_STYLE}{arg}{WARNING_STYLE:#} \
+                in input {PRIMARY_STYLE}{input_name}{PRIMARY_STYLE:#}, \
                 but did not prefix it with {CMD_DOC_STYLE} {GLOB_ESCAPE} {CMD_DOC_STYLE:#}\n\
                 {HELP_STYLE}tip:{HELP_STYLE:#} Consider changing the argument to \
                 {CMD_STYLE}\"{GLOB_ESCAPE}{arg}\"{CMD_STYLE:#} \

--- a/src/gourd_lib/constants.rs
+++ b/src/gourd_lib/constants.rs
@@ -80,7 +80,7 @@ pub const HELP_STYLE: Style = style_from_fg(AnsiColor::Green).bold().underline()
 /// Style of commands in doc messages
 pub const CMD_DOC_STYLE: Style = Style::new()
     .italic()
-    .bg_color(Some(Ansi(AnsiColor::Blue)))
+    .bg_color(Some(Ansi(AnsiColor::BrightBlue)))
     .fg_color(Some(Ansi(AnsiColor::Black)));
 
 /// Style of commands in help messages


### PR DESCRIPTION
this `gourd.toml`:

```toml
output_path = "experiments"
metrics_path = "experiments"
experiments_folder = "experiments"

[program]

[input.a]
arguments = ["xdd", ".", "./", "///", "a///", "./a", "*", "./*", "/a/*", "/*", "*/a"]
```

will result in:

<img width="947" alt="image" src="https://github.com/user-attachments/assets/1266ecaa-f587-4a78-bd20-334b8c65ed4b">
