### PR TITLE
remove tarpaulin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ lto = true
 missing_docs = "warn"
 missing_debug_implementations = "warn"
 missing_copy_implementations = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "warn" }
 
 [lints.clippy]
 redundant_static_lifetimes = "allow"

--- a/docs/maintainer/pipeline.tex
+++ b/docs/maintainer/pipeline.tex
@@ -39,7 +39,7 @@ There are three containers that are needed for the pipeline:
 
 \begin{enumerate}
   \item A container with Rust stable, MSRV version.
-  \item A container with Rust nightly, \texttt{rustfmt}, \texttt{clippy}, \texttt{cargo-tarpaulin}.
+  \item A container with Rust nightly, \texttt{rustfmt}, \texttt{clippy}.
   \item A container with all of TexLive and Rust, MSRV or nightly.
 \end{enumerate}
 

--- a/src/gourd/cli/printing.rs
+++ b/src/gourd/cli/printing.rs
@@ -21,7 +21,6 @@ use inquire::validator::Validation;
 use crate::init::interactive::ask;
 
 /// Util function for getting the style for the CLI
-#[cfg(not(tarpaulin_include))]
 pub fn get_styles() -> clap::builder::Styles {
     clap::builder::Styles::styled()
         .usage(style_from_fg(AnsiColor::Yellow).bold())
@@ -34,7 +33,6 @@ pub fn get_styles() -> clap::builder::Styles {
 }
 
 /// Pretty print gourd's version
-#[cfg(not(tarpaulin_include))]
 pub fn print_version(script: bool) {
     if script {
         println!("{} {}", crate_name!(), crate_version!());

--- a/src/gourd/init/interactive.rs
+++ b/src/gourd/init/interactive.rs
@@ -20,7 +20,6 @@ use log::info;
 
 /// Correctly handles when the user cancels the operation
 /// during an Inquire prompt.
-#[cfg(not(tarpaulin_include))]
 pub fn ask<T>(inq: InquireResult<T>) -> Result<T> {
     match inq {
         Ok(answer) => Ok(answer),

--- a/src/gourd/local/runner.rs
+++ b/src/gourd/local/runner.rs
@@ -31,7 +31,6 @@ pub async fn run_locally(
         )
     }
 
-    #[cfg(not(tarpaulin_include))] // Tarpaulin can't calculate the coverage correctly
     tokio::spawn(async move {
         /// Error in case of wrapper failure.
         fn handle_output(join: io::Result<Output>) {

--- a/src/gourd/main.rs
+++ b/src/gourd/main.rs
@@ -49,7 +49,6 @@ pub mod slurm;
 pub mod init;
 
 /// The command line interface and relevant structures.
-#[cfg(not(tarpaulin_include))]
 pub mod cli;
 
 /// Functionality for checking and displaying the status of already
@@ -81,7 +80,6 @@ pub mod test_utils;
 ///
 /// This function parses command-line arguments and executes
 /// sub-commands as specified by the user.
-#[cfg(not(tarpaulin_include))]
 #[tokio::main]
 async fn main() {
     cli::process::parse_command().await;

--- a/src/gourd/rerun/mod.rs
+++ b/src/gourd/rerun/mod.rs
@@ -1,4 +1,3 @@
-#![cfg(not(tarpaulin_include))]
 /// User interactions for SLURM reruns.
 /// This is interactive and SLURM-bound so cannot be checked locally.
 pub mod slurm;

--- a/src/gourd/slurm/handler.rs
+++ b/src/gourd/slurm/handler.rs
@@ -39,7 +39,6 @@ where
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 impl<T> SlurmHandler<T>
 where
     T: SlurmInteractor,

--- a/src/gourd/slurm/interactor.rs
+++ b/src/gourd/slurm/interactor.rs
@@ -113,7 +113,6 @@ fn scontrol_limit(field: &str) -> Result<String> {
 /// These are using functions specific to CLI version 21.8.x
 ///
 /// we don't know if other versions are supported.
-#[cfg(not(tarpaulin_include))]
 impl SlurmInteractor for SlurmCli {
     fn get_version(&self) -> Result<[u64; 2]> {
         let s_info_out = Command::new("sinfo").arg("--version").output()?;

--- a/src/gourd/status/printing.rs
+++ b/src/gourd/status/printing.rs
@@ -28,7 +28,6 @@ use super::FsState;
 use super::SlurmState;
 use super::Status;
 
-#[cfg(not(tarpaulin_include))] // There are no meaningful tests for an enum's Display implementation
 impl Display for SlurmState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -132,7 +131,6 @@ impl Display for Status {
 /// Display the status of an experiment in a human readable from.
 ///
 /// Returns how many jobs are finished.
-#[cfg(not(tarpaulin_include))] // We won't test stdout
 pub fn display_statuses(
     f: &mut impl Write,
     experiment: &Experiment,
@@ -157,7 +155,6 @@ pub fn display_statuses(
 }
 
 /// Display a shortened status for a lot of runs.
-#[cfg(not(tarpaulin_include))] // We can't test stdout
 fn short_status(
     f: &mut impl Write,
     experiment: &Experiment,
@@ -252,7 +249,6 @@ fn format_input_name(exp: &Experiment, run: &Run, grouped: bool) -> String {
 }
 
 /// Display a shortened status for a small amount of runs.
-#[cfg(not(tarpaulin_include))] // We can't test stdout
 fn long_status(
     f: &mut impl Write,
     experiment: &Experiment,
@@ -405,7 +401,6 @@ fn display_runs(
 }
 
 /// Display the status of an experiment in a human-readable from.
-#[cfg(not(tarpaulin_include))] // We can't test stdout
 pub fn display_job(
     f: &mut impl Write,
     exp: &Experiment,

--- a/src/gourd/status/slurm_based.rs
+++ b/src/gourd/status/slurm_based.rs
@@ -41,7 +41,6 @@ impl<T> StatusProvider<T, SlurmBasedStatus> for SlurmBasedProvider
 where
     T: SlurmInteractor,
 {
-    #[cfg(not(tarpaulin_include))]
     fn get_statuses(
         connection: &T,
         experiment: &Experiment,


### PR DESCRIPTION
it is no longer used since
- test coverage does not make sense for rust
- GitHub does not display these metrics by default (and is a hassle not worthwhile to set it up)